### PR TITLE
Refactor image picker to support single and multiple selection

### DIFF
--- a/app/src/main/java/net/matsudamper/normalize_share_image/PickerActivity.kt
+++ b/app/src/main/java/net/matsudamper/normalize_share_image/PickerActivity.kt
@@ -2,6 +2,7 @@ package net.matsudamper.normalize_share_image
 
 import android.Manifest
 import android.app.Activity
+import android.content.ClipData
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -27,14 +28,26 @@ class PickerActivity : ComponentActivity() {
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) {
-            requestImageSelection()
+            launchImagePicker()
         } else {
             setResult(Activity.RESULT_CANCELED)
             finish()
         }
     }
 
-    private val imagePickerLauncher = registerForActivityResult(
+    private val singleImagePickerLauncher = registerForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null) {
+            hasImagesSelected = true
+            pendingSelectedUris.value = listOf(uri)
+        } else if (!hasImagesSelected) {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+        }
+    }
+
+    private val multipleImagePickerLauncher = registerForActivityResult(
         ActivityResultContracts.GetMultipleContents()
     ) { uris ->
         if (uris.isNotEmpty()) {
@@ -87,12 +100,21 @@ class PickerActivity : ComponentActivity() {
     private fun requestPermissions() {
         permissionLauncher.launch(Manifest.permission.READ_MEDIA_IMAGES)
     }
-    
+
     private fun requestImageSelection() {
         if (checkPermissions()) {
-            imagePickerLauncher.launch("image/*")
+            launchImagePicker()
         } else {
             requestPermissions()
+        }
+    }
+
+    private fun launchImagePicker() {
+        val allowMultiple = intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
+        if (allowMultiple) {
+            multipleImagePickerLauncher.launch("image/*")
+        } else {
+            singleImagePickerLauncher.launch("image/*")
         }
     }
 
@@ -103,15 +125,11 @@ class PickerActivity : ComponentActivity() {
                 data = uris.first()
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             } else {
-                putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                uris.forEachIndexed { index, uri ->
-                    if (index == 0) {
-                        clipData = android.content.ClipData.newRawUri("", uri)
-                    } else {
-                        clipData?.addItem(android.content.ClipData.Item(uri))
-                    }
+                data = uris.first()
+                clipData = ClipData.newRawUri("", uris.first()).also { clip ->
+                    uris.drop(1).forEach { clip.addItem(ClipData.Item(it)) }
                 }
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
         }
         setResult(Activity.RESULT_OK, resultIntent)


### PR DESCRIPTION
## Summary
This PR refactors the image picker functionality to properly handle both single and multiple image selection modes based on the `Intent.EXTRA_ALLOW_MULTIPLE` flag, and improves the result intent construction for multiple images.

## Key Changes
- Split image picker launcher into two separate launchers:
  - `singleImagePickerLauncher`: Uses `GetContent()` for single image selection
  - `multipleImagePickerLauncher`: Uses `GetMultipleContents()` for multiple image selection
- Added `launchImagePicker()` method that checks the `EXTRA_ALLOW_MULTIPLE` intent flag and launches the appropriate picker
- Refactored `returnConvertedImages()` to properly construct the result intent:
  - For single image: Sets `data` field with the URI
  - For multiple images: Sets `data` to the first URI and uses `ClipData` to include all URIs, which is the standard Android approach for sharing multiple items
- Simplified ClipData construction using a more idiomatic Kotlin approach with `also` and `drop()`
- Added `ClipData` import at the top of the file
- Minor code cleanup (trailing whitespace removal)

## Implementation Details
The refactoring ensures that the activity respects the caller's intent regarding single vs. multiple selection, and properly formats the result intent according to Android conventions for sharing multiple items via ClipData.

https://claude.ai/code/session_014ZGeqBT7xjMmepKYLuR4r2