### PR TITLE
Upgrade to AGP 9.2.1 and Kotlin 2.2.10 with modern compiler config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 
@@ -49,11 +50,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.13.2"
-kotlin = "2.2.0"
+agp = "9.2.1"
+kotlin = "2.2.10"
 coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -31,6 +31,5 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
Upgrade Android Gradle Plugin to 9.2.1 and Kotlin to 2.2.10, while modernizing the Kotlin compiler configuration to use the new `kotlin` block instead of the deprecated `kotlinOptions`.

## Key Changes
- Updated AGP from 8.13.2 to 9.2.1
- Updated Kotlin from 2.2.0 to 2.2.10
- Removed deprecated `kotlin-android` plugin (no longer needed with modern AGP)
- Migrated JVM target configuration from `kotlinOptions` block to modern `kotlin.compilerOptions` DSL
- Updated JVM target to use `JvmTarget.JVM_17` enum instead of string literal

## Implementation Details
- Removed `alias(libs.plugins.kotlin.android)` from both `app/build.gradle.kts` and root `build.gradle.kts`
- Replaced the deprecated `kotlinOptions { jvmTarget = "17" }` block with the modern Kotlin compiler options:
  ```kotlin
  kotlin {
      compilerOptions {
          jvmTarget = JvmTarget.JVM_17
      }
  }
  ```
- Added import for `JvmTarget` from `org.jetbrains.kotlin.gradle.dsl`
- Removed `kotlin-android` plugin alias from `gradle/libs.versions.toml`

https://claude.ai/code/session_01DDgmqiVtBVEvePrW1xZHqA