### PR TITLE
Refactor image conversion logic and improve FAB UX

### DIFF
--- a/app/src/main/java/net/matsudamper/normalize_share_image/ui/ImageConverterScreen.kt
+++ b/app/src/main/java/net/matsudamper/normalize_share_image/ui/ImageConverterScreen.kt
@@ -183,6 +183,28 @@ fun ImageConverterScreen(
         selectedImageIndices = emptySet()
     }
 
+    suspend fun convertSelectedImages(): List<ConvertedImage> {
+        isConverting = true
+        val converter = ImageConverter(context)
+        val options = when (applyMode) {
+            ApplyMode.BATCH -> selectedUris.map {
+                PerImageOption(batchFormat, batchQuality)
+            }
+            ApplyMode.INDIVIDUAL -> perImageOptions
+        }
+        val results = converter.convertImagesWithPerImageOptions(
+            uris = selectedUris,
+            contentResolver = context.contentResolver,
+            options = options,
+            onProgress = { current, total ->
+                conversionProgress = current to total
+            }
+        )
+        convertedImages = results
+        isConverting = false
+        return results
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -210,23 +232,45 @@ fun ImageConverterScreen(
             )
         },
         floatingActionButton = {
-            if (convertedImages.isNotEmpty()) {
+            if (selectedUris.isNotEmpty()) {
                 ExtendedFloatingActionButton(
-                    onClick = { onShareImages(convertedImages) },
+                    onClick = {
+                        if (isConverting) return@ExtendedFloatingActionButton
+                        scope.launch {
+                            val results = convertedImages.ifEmpty { convertSelectedImages() }
+                            if (results.isNotEmpty()) {
+                                onShareImages(results)
+                            }
+                        }
+                    },
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary
                 ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_send),
-                        contentDescription = "送信",
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = "送信",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Medium
-                    )
+                    if (isConverting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "変換中... (${conversionProgress.first}/${conversionProgress.second})",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Medium
+                        )
+                    } else {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_send),
+                            contentDescription = "送信",
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "送信",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
                 }
             } else {
                 ExtendedFloatingActionButton(
@@ -315,26 +359,7 @@ fun ImageConverterScreen(
                     }
                 },
                 onConvert = {
-                    scope.launch {
-                        isConverting = true
-                        val converter = ImageConverter(context)
-                        val options = when (applyMode) {
-                            ApplyMode.BATCH -> selectedUris.map {
-                                PerImageOption(batchFormat, batchQuality)
-                            }
-                            ApplyMode.INDIVIDUAL -> perImageOptions
-                        }
-                        val results = converter.convertImagesWithPerImageOptions(
-                            uris = selectedUris,
-                            contentResolver = context.contentResolver,
-                            options = options,
-                            onProgress = { current, total ->
-                                conversionProgress = current to total
-                            }
-                        )
-                        convertedImages = results
-                        isConverting = false
-                    }
+                    scope.launch { convertSelectedImages() }
                 },
                 onAddImages = { openImagePicker() }
             )


### PR DESCRIPTION
## Summary
Refactored the image conversion logic into a reusable suspend function and improved the floating action button (FAB) to show conversion progress and handle the conversion flow more intuitively.

## Key Changes
- **Extracted conversion logic**: Created a new `convertSelectedImages()` suspend function that encapsulates the image conversion workflow, reducing code duplication and improving maintainability
- **Enhanced FAB behavior**: 
  - Changed FAB visibility condition from `convertedImages.isNotEmpty()` to `selectedUris.isNotEmpty()` to allow users to initiate conversion directly from the FAB
  - FAB now triggers conversion on-demand if images haven't been converted yet
  - Added conversion state handling to prevent multiple simultaneous conversions
- **Improved user feedback**:
  - FAB displays a loading spinner and progress text ("変換中... (X/Y)") during conversion
  - FAB is disabled during conversion to prevent accidental multiple submissions
  - Consolidated conversion UI into the FAB instead of requiring a separate convert button interaction

## Implementation Details
- The `convertSelectedImages()` function handles the complete conversion pipeline including progress tracking and state management
- The FAB now uses `convertedImages.ifEmpty { convertSelectedImages() }` to lazily convert images only when needed
- Progress updates are displayed in real-time as "current/total" format during the conversion process

https://claude.ai/code/session_01Cywam9KPbP8W2xXH4Vzphe