### PR TITLE
Change default image format from PNG to JPEG and quality to HIGH

### DIFF
--- a/app/src/main/java/net/matsudamper/normalize_share_image/core/ImageConverter.kt
+++ b/app/src/main/java/net/matsudamper/normalize_share_image/core/ImageConverter.kt
@@ -37,8 +37,8 @@ data class ConvertedImage(
 )
 
 data class PerImageOption(
-    val format: ImageFormat = ImageFormat.PNG,
-    val quality: ImageQuality = ImageQuality.VERY_HIGH
+    val format: ImageFormat = ImageFormat.JPEG,
+    val quality: ImageQuality = ImageQuality.HIGH
 )
 
 class ImageConverter(private val context: Context) {
@@ -51,8 +51,8 @@ class ImageConverter(private val context: Context) {
         convertImagesWithOptions(
             uris = uris,
             contentResolver = contentResolver,
-            format = ImageFormat.PNG,
-            quality = ImageQuality.VERY_HIGH,
+            format = ImageFormat.JPEG,
+            quality = ImageQuality.HIGH,
             onProgress = onProgress
         ).map { it.uri }
     }
@@ -60,8 +60,8 @@ class ImageConverter(private val context: Context) {
     suspend fun convertImagesWithOptions(
         uris: List<Uri>,
         contentResolver: ContentResolver,
-        format: ImageFormat = ImageFormat.PNG,
-        quality: ImageQuality = ImageQuality.VERY_HIGH,
+        format: ImageFormat = ImageFormat.JPEG,
+        quality: ImageQuality = ImageQuality.HIGH,
         onProgress: (Int, Int) -> Unit = { _, _ -> }
     ): List<ConvertedImage> = withContext(Dispatchers.IO) {
         val options = uris.map { PerImageOption(format, quality) }

--- a/app/src/main/java/net/matsudamper/normalize_share_image/ui/ImageConverterScreen.kt
+++ b/app/src/main/java/net/matsudamper/normalize_share_image/ui/ImageConverterScreen.kt
@@ -98,8 +98,8 @@ fun ImageConverterScreen(
 
     var selectedUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var applyMode by remember { mutableStateOf(ApplyMode.BATCH) }
-    var batchFormat by remember { mutableStateOf(ImageFormat.PNG) }
-    var batchQuality by remember { mutableStateOf(ImageQuality.VERY_HIGH) }
+    var batchFormat by remember { mutableStateOf(ImageFormat.JPEG) }
+    var batchQuality by remember { mutableStateOf(ImageQuality.HIGH) }
     var perImageOptions by remember { mutableStateOf<List<PerImageOption>>(emptyList()) }
     var convertedImages by remember { mutableStateOf<List<ConvertedImage>>(emptyList()) }
     var isConverting by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary
Updated the default image conversion settings to use JPEG format with HIGH quality instead of PNG with VERY_HIGH quality. This change affects both the default parameters and UI initialization across the image conversion pipeline.

## Key Changes
- Changed default `ImageFormat` from `PNG` to `JPEG` in `PerImageOption` data class
- Changed default `ImageQuality` from `VERY_HIGH` to `HIGH` in `PerImageOption` data class
- Updated `convertImages()` method to use new defaults (JPEG, HIGH)
- Updated `convertImagesWithOptions()` method signature defaults to match (JPEG, HIGH)
- Updated UI state initialization in `ImageConverterScreen` to use new defaults for batch conversion mode

## Implementation Details
The changes maintain backward compatibility by updating all default values consistently across:
- Data class defaults
- Function parameter defaults
- UI state initialization

This ensures a uniform user experience with the new default settings throughout the application.

https://claude.ai/code/session_01T65aaURUDqxBwKNVaJyRBo